### PR TITLE
DEMO: Demonstrate es2017 vs es5

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "scripts": {
     "test": "jest --coverage && yarn run compile",
+    "test:types5": "tsc --noEmit --moduleResolution node --noImplicitReturns --skipLibCheck -t ES5 ./src/*.ts",
+    "test:types2017": "tsc --noEmit --moduleResolution node --noImplicitReturns --skipLibCheck -t ES2017 ./src/*.ts",
     "compile": "tsc -p ./tsconfig.json --noEmit",
     "prettier": "prettier 'src/**/*.ts' --write",
     "docs:install": "cd docs && yarn",

--- a/src/zipWith.ts
+++ b/src/zipWith.ts
@@ -66,6 +66,9 @@ export function zipWith() {
   if (args.length === 3) {
     return _zipWith(args[0], args[1], args[2]);
   }
+
+  // TODO: decide on best return here
+  return undefined;
 }
 
 function _zipWith<F, S, R>(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,15 +30,15 @@
     "strict": true /* Enable all strict type-checking options. */,
     "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
     "strictNullChecks": true /* Enable strict null checks. */,
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+    "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
     "noUnusedLocals": true /* Report errors on unused locals. */,
     "noUnusedParameters": false /* Report errors on unused parameters. */,
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
 
     /* Module Resolution Options */


### PR DESCRIPTION
This PR should NOT be merged; it's only for discussion.

I set out to fancy up the typings for `guards.isPromise()`.

I began by writing a failing test that would catch the type error, but I found it's very dependent on the target (or polyfill libs added).  I don't see a great way to recreate or fix this within the library.
